### PR TITLE
Allow for build on closure of pull requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
     paths: [docs/**, .github/workflows/**]
+  pull_request:
+    branches: [main]
+    paths: [docs/**, .github/workflows/**]
+
+
 
 jobs:
   deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ yarn-error.log*
 
 public/pdf.worker.js
 public/js9
+
+launch.json
+/.vscode
+/.idea


### PR DESCRIPTION
When you closed my pull request about the keep offsets button, github didn't build a new version because you set it to build on push, and a pull request doesn't count. I updated the github workflow to build on closure of pull requests. The real question is whether or not THIS pull request will create a new build.